### PR TITLE
added base locations to Region

### DIFF
--- a/MapData.py
+++ b/MapData.py
@@ -2,17 +2,19 @@ import numpy as np
 from scipy.ndimage import binary_fill_holes, generate_binary_structure, label
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-
+from sc2.game_info import GameInfo
+from sc2.position import Point2
 from Region import Region
+from typing import List
 
 
 class MapData:
-    def __init__(self, map_name, game_info):
+    def __init__(self, map_name: str, game_info: GameInfo, base_locations: List[Point2]):
 
         self.map_name = map_name
         self.placement_arr = game_info.placement_grid.data_numpy
         self.path_arr = game_info.pathing_grid.data_numpy
-        # self.terrain_height = terrain_height
+        self.base_locations = base_locations
         self.region_grid = None
         self.regions = {}
         self.compile_map()
@@ -31,7 +33,7 @@ class MapData:
         regions_labels = np.unique(labeled_array)
 
         for i in range(len(regions_labels)):
-            region = Region(array=np.where(region_grid == i, 1, 0), label=i)
+            region = Region(array=np.where(region_grid == i, 1, 0), label=i, map_expansions=self.base_locations)
             self.regions[i] = region
         self.region_grid = region_grid
 

--- a/Polygon.py
+++ b/Polygon.py
@@ -19,7 +19,6 @@ class Polygon:
         cm = center_of_mass(self.array)
         return np.int(cm[0]), np.int(cm[1])
 
-    @property
     def is_inside(self, point):
         return point[0] in self.indices[1] and point[1] in self.indices[0]
 

--- a/Region.py
+++ b/Region.py
@@ -1,11 +1,16 @@
 from Polygon import Polygon
 import matplotlib.pyplot as plt
+import numpy as np
+from sc2.position import Point2
+from typing import List
+
 
 class Region:
-    def __init__(self, array, label):
+    def __init__(self, array: np.ndarray, label: int, map_expansions: List[Point2]):
         self.array = array
         self.label = label
         self.polygon = Polygon(self)
+        self.bases = [base for base in map_expansions if self.polygon.is_inside((base.rounded[1], base.rounded[0]))]
 
     def plot_perimeter(self):
         x, y = zip(*self.polygon.perimeter)
@@ -19,7 +24,7 @@ class Region:
 
     @property
     def base_locations(self):
-        pass
+        return self.bases
 
     @property
     def is_reachable(self, region):  # is connected to another region directly ?

--- a/run.py
+++ b/run.py
@@ -1,20 +1,34 @@
-import pickle, lzma
+import pickle
+import lzma
 from MapData import MapData
+from sc2.game_data import GameData
 from sc2.game_info import GameInfo
+from sc2.game_state import GameState
+from sc2.player import BotAI
 
 if __name__ == "__main__":
-    # with open("pickle_gameinfo/placement_gridPillarsofGoldLE", "rb") as f:
-    #     #     placement_arr = pickle.load(f)
-    #     # with open("pickle_gameinfo/pathing_gridPillarsofGoldLE", "rb") as f:
-    #     #     path_arr = pickle.load(f)
-    #     # with open("pickle_gameinfo/terrain_heightPillarsofGoldLE", "rb") as f:
-    #     #     terrain_height = pickle.load(f)
-    with lzma.open("pickle_gameinfo/AbyssalReefLE.xz", "rb") as f:
+    with lzma.open("pickle_data/PillarsofGoldLE.xz", "rb") as f:
         raw_game_data, raw_game_info, raw_observation = pickle.load(f)
 
+    bot = BotAI()
+    game_data = GameData(raw_game_data.data)
     game_info = GameInfo(raw_game_info.game_info)
-    map_name = "PillarsofGoldLE"
-    map_data = MapData(map_name, game_info)
+    game_state = GameState(raw_observation)
+    # noinspection PyProtectedMember
+    bot._initialize_variables()
+    # noinspection PyProtectedMember
+    bot._prepare_start(client=None, player_id=1, game_info=game_info, game_data=game_data)
+    # noinspection PyProtectedMember
+    bot._prepare_step(state=game_state, proto_game_info=raw_game_info)
+    # noinspection PyProtectedMember
+    bot._find_expansion_locations()
+    game_info = GameInfo(raw_game_info.game_info)
+    map_name = game_info.map_name
+    map_data = MapData(
+        map_name=map_name,
+        game_info=game_info,
+        base_locations=bot.expansion_locations_list
+    )
     map_data.plot_regions_by_label()
     for label, region in map_data.regions.items():
         region.plot_perimeter()


### PR DESCRIPTION
I added some steps to `run.py` so that the expansion locations for a map could be pulled from the `.xz` file. When constructing a Region, the list of expansions on the map is now passed and the locations are checked against the Polygon created for the Region. `Polygon.is_inside` didn't work unless I removed the `@property` decorator, so I removed that.