### PR TITLE
api change

### DIFF
--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -315,13 +315,15 @@ class MapData:
                         array=new_choke_array,
                         main_line=choke.main_line,
                 )
-                region = self.in_region_p(new_choke.center)
-                if region:
-                    region.region_chokes.append(new_choke)
-                    new_choke.regions.append(region)
-                if region is None and self.where(new_choke.center) is None:
+                areas = self.where_all(new_choke.center)
+                if len(areas) > 0:
+                    for area in areas:
+                        if isinstance(area, Region):
+                            area.region_chokes.append(new_choke)
+                        new_choke.areas.append(area)
+                else:
                     print(
-                            f"<{self.bot.game_info.map_name}>: please report bug no region found for choke area with center {new_choke.center}"
+                            f"<{self.bot.game_info.map_name}>: please report bug no area found for choke area with center {new_choke.center}"
                     )
                 self.map_chokes.append(new_choke)
 

--- a/MapAnalyzer/constructs.py
+++ b/MapAnalyzer/constructs.py
@@ -20,6 +20,7 @@ class ChokeArea(Polygon):
             self, array: np.ndarray, map_data: "MapData", main_line: Tuple = None
     ):
         self.regions = []  # set by map_data
+        self.areas = []  # set by map_data
         self.main_line = main_line
         super().__init__(map_data=map_data, array=array)
 
@@ -33,7 +34,7 @@ class ChokeArea(Polygon):
             return math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 
     def __repr__(self):
-        return f"<ChokeArea;{self.area}> of {[r for r in self.regions]}"
+        return f"<ChokeArea;{self.area}> of {[r for r in self.areas]}"
 
 
 class MDRamp(ChokeArea):
@@ -69,5 +70,5 @@ class VisionBlockerArea(ChokeArea):
 
     def __repr__(self):
         return (
-                f"<VisionBlockerArea;{self.area}> of {[r for r in self.regions]}"
+                f"<VisionBlockerArea;{self.area}> of {[r for r in self.areas]}"
         )


### PR DESCRIPTION
ChokeArea now has self.areas  that points to any construct that choke is in
all constructs __repr__ will now print the areas they are in
the only exception is MDRamp,  which is connected to Regions only

Signed-off-by: eladyaniv01 <eladyaniv01@gmail.com>