### PR TITLE
Add new add_cost_to_multiple_grids method

### DIFF
--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -398,8 +398,9 @@ class MapData:
         Example:
             >>> air_grid = self.get_clean_air_grid()
             >>> ground_grid = self.get_pyastar_grid()
-            >>> air_grid, ground_grid = self.add_cost_to_multiple_grids(
-            >>>     position=self.bot.game_info.map_center, radius=5, grids=[air_grid, ground_grid], weight=10)
+            >>> # commented out for doc test
+            >>> # air_grid, ground_grid = self.add_cost_to_multiple_grids(
+            >>> #    position=self.bot.game_info.map_center, radius=5, grids=[air_grid, ground_grid], weight=10)
 
         Warning:
             When ``safe=False`` the Pather will not adjust illegal values below 1 which could result in a crash`

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -396,13 +396,10 @@ class MapData:
         calculated once.
 
         Example:
-            >>> MARINE_RANGE: int = 5
             >>> air_grid = self.get_clean_air_grid()
             >>> ground_grid = self.get_pyastar_grid()
-            >>> # start / goal could be any tuple / Point2
-            >>> enemy_marine = self.enemy_units.by_tag(self.enemy_marine_tag)
             >>> air_grid, ground_grid = self.add_cost_to_multiple_grids(
-            >>>     position=enemy_marine.position, radius=MARINE_RANGE, grids=[air_grid, ground_grid], weight=10)
+            >>>     position=self.bot.game_info.map_center, radius=5, grids=[air_grid, ground_grid], weight=10)
 
         Warning:
             When ``safe=False`` the Pather will not adjust illegal values below 1 which could result in a crash`

--- a/MapAnalyzer/MapData.py
+++ b/MapAnalyzer/MapData.py
@@ -372,9 +372,64 @@ class MapData:
         Warning:
             When ``safe=False`` the Pather will not adjust illegal values below 1 which could result in a crash`
 
+        See Also:
+            * :meth:`.MapData.add_cost_to_multiple_grids`
+
         """
         return self.pather.add_cost(position=position, radius=radius, arr=grid, weight=weight, safe=safe,
                                     initial_default_weights=initial_default_weights)
+
+    def add_cost_to_multiple_grids(
+        self,
+        position: Tuple[float, float],
+        radius: float,
+        grids: List[ndarray],
+        weight: float = 100,
+        safe: bool = True,
+        initial_default_weights: float = 0,
+    ) -> List[ndarray]:
+        """
+        :rtype: List[numpy.ndarray]
+
+        Like ``add_cost``, will add cost to a `circle-shaped` area with a center ``position`` and radius ``radius``
+        Use this one for performance reasons if adding identical cost to multiple grids, so that the disk is only
+        calculated once.
+
+        Example:
+            >>> MARINE_RANGE: int = 5
+            >>> air_grid = self.get_clean_air_grid()
+            >>> ground_grid = self.get_pyastar_grid()
+            >>> # start / goal could be any tuple / Point2
+            >>> enemy_marine = self.enemy_units.by_tag(self.enemy_marine_tag)
+            >>> air_grid, ground_grid = self.add_cost_to_multiple_grids(
+            >>>     position=enemy_marine.position, radius=MARINE_RANGE, grids=[air_grid, ground_grid], weight=10)
+
+        Warning:
+            When ``safe=False`` the Pather will not adjust illegal values below 1 which could result in a crash`
+
+        Tip:
+            Performance against using `add_cost` for multiple grids, averaged over 1000 iterations
+            For `add_cost` the method was called once per grid
+
+            2 grids `add_cost_to_multiple_grids`: 188.18 µs ± 12.73 ns per loop
+            2 grids `add_cost`                  : 229.95 µs ± 37.53 ns per loop
+
+            3 grids `add_cost_to_multiple_grids`: 199.15 µs ± 21.86 ns per loop
+            3 grids `add_cost`                  : 363.44 µs ± 80.89 ns per loop
+
+            4 grids `add_cost_to_multiple_grids`: 222.34 µs ± 26.79 ns per loop
+            4 grids `add_cost`                  : 488.94 µs ± 87.64 ns per loop
+
+        """
+        return self.pather.add_cost_to_multiple_grids(
+            position=position,
+            radius=radius,
+            arrays=grids,
+            weight=weight,
+            safe=safe,
+            initial_default_weights=initial_default_weights,
+        )
+
 
     """Utility methods"""
 


### PR DESCRIPTION
When building a complex bot the need for multiple grids arises, for each of these grids we often want to add identical cost to each one. This has a performance impact since the `disk` has to be repeatedly calculated (via `draw_circle` and `_bounded_circle`). Therefore a new `add_cost_to_multiple_grids` has been added so that this disk is only calculated once, and then added to each grid the use has passed in.

This has a significant improvement with the number of grids that are passed in against using `add_cost` for each one, as shown from timing tests:
```
            2 grids `add_cost_to_multiple_grids`: 188.18 µs ± 12.73 ns per loop
            2 grids `add_cost`                  : 229.95 µs ± 37.53 ns per loop

            3 grids `add_cost_to_multiple_grids`: 199.15 µs ± 21.86 ns per loop
            3 grids `add_cost`                  : 363.44 µs ± 80.89 ns per loop

            4 grids `add_cost_to_multiple_grids`: 222.34 µs ± 26.79 ns per loop
            4 grids `add_cost`                  : 488.94 µs ± 87.64 ns per loop
     
```

I left this information in the method signature too.

In the bot we are developing the need for 5+ grids has come about where various duplicate costs are added to each one. This should allow the scaling of how many grids are used in a sustainable way.